### PR TITLE
Etags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@
 /ash-tray
 .env
 /cdn/*
-test*
+/test/*
 

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,0 +1,12 @@
+FROM golang AS build
+WORKDIR /app
+COPY main.go main.go
+COPY utils.go utils.go
+COPY go.sum go.sum
+COPY go.mod go.mod
+
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=linux go build -o /od-ash-tray .
+
+CMD ["/od-ash-tray"]
+

--- a/ci-Dockerfile
+++ b/ci-Dockerfile
@@ -1,6 +1,0 @@
-FROM golang AS build
-WORKDIR /app
-COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -o /od-ash-tray .
-
-CMD ["/od-ash-tray"]

--- a/ci-compose.yaml
+++ b/ci-compose.yaml
@@ -1,7 +1,7 @@
 services:
   od-ash_tray:
     build:
-      dockerfile: ci-Dockerfile
+      dockerfile: Dockerfile.ci
     ports: 
       - "0.0.0.0:7377:7377"
     environment:

--- a/launch-test-env.sh
+++ b/launch-test-env.sh
@@ -2,8 +2,15 @@
 
 set -eu
 
+TESTDIR=${TESTDIR:-test}
 COMPOSE_FLAGS=(-f ci-compose.yaml)
 ASH_HOST="http://127.0.0.1:7377"
+
+function get_etag_from_logs() {
+  tac "${TESTDIR}"/tests.out.logs |
+    grep -oPm1 '(?<=Etag: )[\w]+' |
+    xargs echo -n
+}
 
 function print_usage() {
   echo "Usage: ./launch-test-env.sh [OPTION]"
@@ -13,7 +20,6 @@ function print_usage() {
   echo "   -t          run tests..."
   echo "   -b          skip rebuild"
 }
-
 
 function cleanup() {
   echo "========= CLEANING UP COMPOSE ==========="
@@ -33,35 +39,44 @@ t_flag=''
 b_flag=''
 while getopts 'htcWb' flag; do
   case "${flag}" in
-    b) b_flag='true';;
-    t) t_flag='true';;
-    c) cleanup
-       exit 0;;
-    W) wipeout
-       exit 0;;
-    h) print_usage
-       exit 0 ;;
-    *) print_usage
-       exit 1 ;;
+  b) b_flag='true' ;;
+  t) t_flag='true' ;;
+  c)
+    cleanup
+    exit 0
+    ;;
+  W)
+    wipeout
+    exit 0
+    ;;
+  h)
+    print_usage
+    exit 0
+    ;;
+  *)
+    print_usage
+    exit 1
+    ;;
   esac
 done
 
 echo "========= BUILDING PROJECT ==========="
 if ! [[ "${b_flag}" == "true" ]]; then
-  docker compose "${COMPOSE_FLAGS[@]}" build --no-cache
+  docker compose "${COMPOSE_FLAGS[@]}" build
 fi
 docker compose "${COMPOSE_FLAGS[@]}" up -d
 
 if [[ "$t_flag" == "true" ]]; then
   echo "========= RUNNING TESTS ==========="
-  for file in ./shadows/* ; do
+  [ -d "${TESTDIR}" ] || mkdir "${TESTDIR}"
+  for file in ./shadows/*; do
     printf " TESTING: %s" "${file}..."
-    cdn_file=$(curl -ksi -X POST -H "Content-Type: multipart/form-data" -F "data=@${file}" "${ASH_HOST}"/ash/upload | tail -n1)
-    curl -ks "${ASH_HOST}"/"${cdn_file}" -o test
-    diff test "${file}"
-    echo " PASSED"    
+    cdn_file=$(curl -vksi -X POST -H "Content-Type: multipart/form-data" -F "data=@${file}" "${ASH_HOST}"/ash/upload |& tee -a "${TESTDIR}"/tests.logs | tail -n1)
+    curl -vks "${ASH_HOST}"/"${cdn_file}" -o "${TESTDIR}"/test 2>>"${TESTDIR}"/tests.out.logs
+    diff "${TESTDIR}"/test "${file}"
+    curl -vkH "If-None-Match: $(get_etag_from_logs)" "${ASH_HOST}"/"${cdn_file}" |& grep -q '304 Not Modified'
+    echo " PASSED"
   done
 
   cleanup
 fi
-

--- a/main.go
+++ b/main.go
@@ -275,6 +275,8 @@ func higherTray(httpWriter http.ResponseWriter, req *http.Request) {
 	if req.Method == "GET" {
 		if req.URL.Path == "/ash/ping" {
 			fmt.Fprintf(httpWriter, "ping")
+		} else if req.URL.Path == "/pong" {
+			fmt.Fprintf(httpWriter, "pong")
 		} else {
 			ashGet(httpWriter, req)
 		}

--- a/main.go
+++ b/main.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"crypto/aes"
-	"crypto/sha256"
 	"crypto/cipher"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
@@ -14,7 +14,7 @@ import (
 	"os"
 	"strings"
 	"time"
-	
+
 	"github.com/google/uuid"
 )
 
@@ -51,7 +51,7 @@ func createNewAshTray(req *http.Request) (string, string) {
 	}
 
 	// TODO: see if we could use something stronger then
-	//       SHA256 here... maybe argon2? 
+	//       SHA256 here... maybe argon2?
 	sha := sha256.Sum256([]byte(dirUUID[:]))
 	directory := hex.EncodeToString(sha[:])
 	filename := hex.EncodeToString(newUUID[:])
@@ -73,82 +73,80 @@ func createNewAshTray(req *http.Request) (string, string) {
 }
 
 func writeToFile(filePath string, directory string, data []byte) {
-
 	_ = os.Mkdir(fmt.Sprintf("%s/%s/%s", ashTrayDir, ashID, directory), os.ModePerm)
 
-	ashFile, err := os.OpenFile(fmt.Sprintf("%s/%s", ashTrayDir, filePath), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	ashFile, err := os.OpenFile(fmt.Sprintf("%s/%s", ashTrayDir, filePath), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
 		log.Fatal(err)
 	}
+	// TODO: wow what a retarded fucking way to do things...
 	defer ashFile.Close()
 
 	ashFile.Write(data)
 }
 
 func encryptData(data string) ([]byte, error) {
-	
 	aesBlock, err := aes.NewCipher(ashKey)
 	if err != nil {
 		return nil, err
 	}
-	
+
 	gcm, err := cipher.NewGCM(aesBlock)
 	if err != nil {
 		return nil, err
 	}
-	
+
 	nonce := make([]byte, gcm.NonceSize())
 	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
 		return nil, err
 	}
-	
+
 	ciphertext := gcm.Seal(nil, nonce, []byte(data), nil)
-	
+
 	encryptedLen := len(nonce) + len(ciphertext)
 	result := make([]byte, 4+encryptedLen)
 	binary.BigEndian.PutUint32(result[:4], uint32(encryptedLen))
 	copy(result[4:], nonce)
 	copy(result[4+len(nonce):], ciphertext)
-	
+
 	return result, nil
 }
 
 func decryptData(data []byte) ([]byte, error) {
-	
 	if len(data) < 4 {
 		return nil, fmt.Errorf("data too short")
 	}
-	
+
 	expectedLen := int(binary.BigEndian.Uint32(data[:4]))
 	if len(data) < 4+expectedLen {
 		return nil, fmt.Errorf("incomplete data")
 	}
-	
+
 	encryptedData := data[4 : 4+expectedLen]
-	
+
 	aesBlock, err := aes.NewCipher(ashKey)
 	if err != nil {
 		return nil, err
 	}
-	
+
 	gcm, err := cipher.NewGCM(aesBlock)
 	if err != nil {
 		return nil, err
 	}
-	
+
 	nonceSize := gcm.NonceSize()
 	if len(encryptedData) < nonceSize {
 		return nil, fmt.Errorf("encrypted data too short")
 	}
-	
+
 	nonce := encryptedData[:nonceSize]
 	ciphertext := encryptedData[nonceSize:]
-	
+
 	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
 	if err != nil {
 		return nil, err
 	}
-	
+
 	return plaintext, nil
 }
 
@@ -156,10 +154,17 @@ func fileDownload(httpWriter http.ResponseWriter, req *http.Request) {
 	filePath := fmt.Sprintf("%s%s", ashTrayDir, req.URL.Path)
 	fmt.Printf(" + fileDownload(): filePath=%s\n", filePath)
 
+	if state, etag := isEtagValid(filePath, httpWriter, req); state {
+		return
+	} else {
+		fmt.Printf("   set etag to: %s\n", etag)
+		httpWriter.Header().Set("Etag", etag)
+	}
+
 	file, err := os.Open(filePath)
 	if err != nil {
 		fmt.Printf("   %s file doesn't exist\n", filePath)
-		
+
 		httpWriter.WriteHeader(404)
 		fmt.Fprintf(httpWriter, "404 Not Found \r\n")
 		return
@@ -180,22 +185,22 @@ func fileDownload(httpWriter http.ResponseWriter, req *http.Request) {
 			fmt.Fprintf(httpWriter, "Failed at reading from file.")
 			break
 		}
-		
+
 		if readTotal == 0 {
 			break
 		}
-		
+
 		data := append(leftover, buffer[:readTotal]...)
 		leftover = nil
-		
+
 		offset := 0
 		for offset+4 <= len(data) {
-			blockLen := int(binary.BigEndian.Uint32(data[offset:offset+4]))
+			blockLen := int(binary.BigEndian.Uint32(data[offset : offset+4]))
 			if offset+4+blockLen > len(data) {
 				leftover = data[offset:]
 				break
 			}
-			
+
 			decryptedData, err := decryptData(data[offset : offset+4+blockLen])
 			if err != nil {
 				fmt.Println(err)
@@ -203,15 +208,15 @@ func fileDownload(httpWriter http.ResponseWriter, req *http.Request) {
 				fmt.Fprintf(httpWriter, "Failed at file decryption.")
 				return
 			}
-			
+
 			httpWriter.Write(decryptedData)
 			offset += 4 + blockLen
 		}
-		
+
 		if offset < len(data) && leftover == nil {
 			leftover = data[offset:]
 		}
-		
+
 		if err == io.EOF {
 			break
 		}
@@ -250,7 +255,7 @@ func fileUpload(httpWriter http.ResponseWriter, req *http.Request) {
 		}
 	}
 	httpWriter.WriteHeader(201)
-	fmt.Fprintf(httpWriter,"%s", filePath)
+	fmt.Fprintf(httpWriter, "%s", filePath)
 }
 
 func higherTrayTimer() func() {
@@ -269,14 +274,12 @@ func higherTray(httpWriter http.ResponseWriter, req *http.Request) {
 
 	fmt.Printf("[%s] %s: %s\n", req.Method, req.RemoteAddr, req.URL)
 	req.ParseMultipartForm(MaxFormMemorySize)
-	
+
 	httpWriter.Header().Set("Access-Control-Allow-Origin", "*")
 
 	if req.Method == "GET" {
 		if req.URL.Path == "/ash/ping" {
 			fmt.Fprintf(httpWriter, "ping")
-		} else if req.URL.Path == "/pong" {
-			fmt.Fprintf(httpWriter, "pong")
 		} else {
 			ashGet(httpWriter, req)
 		}
@@ -289,7 +292,6 @@ func higherTray(httpWriter http.ResponseWriter, req *http.Request) {
 }
 
 func main() {
-
 	if ashTrayDir == "" {
 		fmt.Println("ASH_TRAY_DIRECTORY env var MUST be set")
 		return

--- a/main.go
+++ b/main.go
@@ -154,11 +154,23 @@ func fileDownload(httpWriter http.ResponseWriter, req *http.Request) {
 	filePath := fmt.Sprintf("%s%s", ashTrayDir, req.URL.Path)
 	fmt.Printf(" + fileDownload(): filePath=%s\n", filePath)
 
-	if state, etag := isEtagValid(filePath, httpWriter, req); state {
+	switch state, err := isEtagValid(filePath, httpWriter, req); state {
+	case CannotOpenFile:
+		fmt.Printf("   %s cannot open file: %s\n", err, filePath)
+
+		httpWriter.WriteHeader(500)
+		fmt.Fprintf(httpWriter, "500 Failed to open file.\r\n")
 		return
-	} else {
-		fmt.Printf("   set etag to: %s\n", etag)
-		httpWriter.Header().Set("Etag", etag)
+	case CannotCreateEtag:
+		fmt.Printf("   %s cannot create etag for:\n", err)
+		httpWriter.WriteHeader(500)
+		fmt.Fprintf(httpWriter, "500 Failed to create etag \r\n")
+		return
+	case ValidEtag:
+		fmt.Printf("   etag HIT")
+		return
+	case InvalidEtag:
+		fmt.Printf("   etag MISS")
 	}
 
 	file, err := os.Open(filePath)

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/http"
+	"os"
+	"strings"
+)
+
+func shaFile(file fs.File) (string, error) {
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+func isEtagValid(filePath string, httpWriter http.ResponseWriter, req *http.Request) (bool, string) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		fmt.Printf("   %s cannot open file: %s\n", err, filePath)
+
+		httpWriter.WriteHeader(500)
+		fmt.Fprintf(httpWriter, "500 Failed to open file.\r\n")
+
+		// Same remark as below...
+		return true, ""
+	}
+	defer file.Close()
+
+	etag, err := shaFile(file)
+	if err != nil {
+		fmt.Printf("   %s cannot create etag for:\n", err)
+
+		httpWriter.WriteHeader(500)
+		fmt.Fprintf(httpWriter, "500 Failed to create etag \r\n")
+
+		// Hmmm... Unfortunately, I can't think of a better value to return here.
+		// Saying that the etag is valid here means that we just respond
+		// with 500 higher up, and no more processing returns. But... yeah
+		// it's sort of unintuitive...
+		return true, ""
+	}
+
+	if match := req.Header.Get("If-None-Match"); match != "" {
+		if strings.Contains(match, etag) {
+			httpWriter.WriteHeader(http.StatusNotModified)
+			return true, etag
+		}
+	}
+
+	return false, etag
+}

--- a/utils.go
+++ b/utils.go
@@ -3,12 +3,20 @@ package main
 import (
 	"crypto/sha256"
 	"encoding/hex"
-	"fmt"
 	"io"
 	"io/fs"
 	"net/http"
 	"os"
 	"strings"
+)
+
+type EtagState int
+
+const (
+	CannotOpenFile EtagState = iota
+	CannotCreateEtag
+	ValidEtag
+	InvalidEtag
 )
 
 func shaFile(file fs.File) (string, error) {
@@ -19,39 +27,25 @@ func shaFile(file fs.File) (string, error) {
 	return hex.EncodeToString(hash.Sum(nil)), nil
 }
 
-func isEtagValid(filePath string, httpWriter http.ResponseWriter, req *http.Request) (bool, string) {
+func isEtagValid(filePath string, httpWriter http.ResponseWriter, req *http.Request) (EtagState, error) {
 	file, err := os.Open(filePath)
 	if err != nil {
-		fmt.Printf("   %s cannot open file: %s\n", err, filePath)
-
-		httpWriter.WriteHeader(500)
-		fmt.Fprintf(httpWriter, "500 Failed to open file.\r\n")
-
-		// Same remark as below...
-		return true, ""
+		return CannotOpenFile, err
 	}
 	defer file.Close()
 
 	etag, err := shaFile(file)
 	if err != nil {
-		fmt.Printf("   %s cannot create etag for:\n", err)
-
-		httpWriter.WriteHeader(500)
-		fmt.Fprintf(httpWriter, "500 Failed to create etag \r\n")
-
-		// Hmmm... Unfortunately, I can't think of a better value to return here.
-		// Saying that the etag is valid here means that we just respond
-		// with 500 higher up, and no more processing returns. But... yeah
-		// it's sort of unintuitive...
-		return true, ""
+		return CannotCreateEtag, err
 	}
 
 	if match := req.Header.Get("If-None-Match"); match != "" {
 		if strings.Contains(match, etag) {
 			httpWriter.WriteHeader(http.StatusNotModified)
-			return true, etag
+			return ValidEtag, nil
 		}
 	}
 
-	return false, etag
+	httpWriter.Header().Set("Etag", etag)
+	return InvalidEtag, nil
 }


### PR DESCRIPTION
Firstly, here are some helpful resources for
learning about etags:
https://en.wikipedia.org/wiki/HTTP_ETag
https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/ETag

Etags are used to cache requests. If a browser
sees an etag, it stores both the payload and
the etag in its internal persistent memory.

Now the next time it does the request, it asks
the server whether the etag is still valid. If
it is, the browser loads the cached image. If
it is not valid then the server sends the image
again.